### PR TITLE
Add dev dependencies to gemspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /coverage
 /*.gem
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gemspec

--- a/z3.gemspec
+++ b/z3.gemspec
@@ -12,5 +12,10 @@ Gem::Specification.new do |s|
   s.homepage     = "https://github.com/taw/z3"
   s.license      = "MIT"
   s.requirements = "z3 library"
+  # development
+  s.add_development_dependency 'pry'
+  # tests
+  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'simplecov'
   s.add_runtime_dependency 'ffi'
 end


### PR DESCRIPTION
Add development dependencies to gemspec and a `Gemfile` to make hacking on the gem easier.