### PR TITLE
context.rb - Z3_mk_context requires a config pointer

### DIFF
--- a/lib/z3/context.rb
+++ b/lib/z3/context.rb
@@ -1,7 +1,7 @@
 class Z3::Context
   attr_reader :_context
   def initialize
-    @_context = Z3::LowLevel.mk_context
+    @_context = Z3::LowLevel.mk_context(Z3::LowLevel.mk_config)
   end
 
   def self.instance

--- a/lib/z3/low_level.rb
+++ b/lib/z3/low_level.rb
@@ -16,8 +16,12 @@ module Z3::LowLevel
       Z3::VeryLowLevel.Z3_set_error_handler(_ctx_pointer, block)
     end
 
-    def mk_context
-      Z3::VeryLowLevel.Z3_mk_context
+    def mk_context(config)
+      Z3::VeryLowLevel.Z3_mk_context(config)
+    end
+
+    def mk_config
+      Z3::VeryLowLevel.Z3_mk_config
     end
 
     def model_eval(model, ast, model_completion)

--- a/lib/z3/very_low_level.rb
+++ b/lib/z3/very_low_level.rb
@@ -29,7 +29,7 @@ module Z3::VeryLowLevel
   callback :error_handler, [:pointer, :int], :void
   attach_function :Z3_get_version, [:pointer, :pointer, :pointer, :pointer], :void
   attach_function :Z3_set_error_handler, [:ctx_pointer, :error_handler], :void
-  attach_function :Z3_mk_context, [], :ctx_pointer
+  attach_function :Z3_mk_context, [:config_pointer], :ctx_pointer
   attach_function :Z3_model_eval, [:ctx_pointer, :model_pointer, :ast_pointer, :bool, :pointer], :int
   attach_function :Z3_mk_and, [:ctx_pointer, :int, :pointer], :ast_pointer
   attach_function :Z3_mk_or, [:ctx_pointer, :int, :pointer], :ast_pointer


### PR DESCRIPTION
Pass a cfg_pointer (return value of Z3_mk_config) to Z3_mk_context.

Looks like the definition of Z3_mk_context specifies it,

[Z3_context Z3_API Z3_mk_context(Z3_config c)](https://github.com/Z3Prover/z3/blob/z3-4.4.1/src/api/api_context.cpp#L423)

but the function implementation does not check its presence.

This causes a std::bad_alloc error on Linux 4.2.0 and is reproducible on
ubuntu 15.10, z3 ver 4.4.1 - commit 95c9ccb2, ruby 2.2.3 using the
following test:

```
module Z3
end

require_relative './lib/z3/very_low_level'
require_relative './lib/z3/very_low_level_auto'

Z3::VeryLowLevel.Z3_mk_context()
```