### PR TITLE
Completed install info in README for Linux.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ To use it, you'll need to install `z3`. On OSX that would be:
 
 On other systems use appropriate package manager.
 
+*NB: On Linux, since FFI will look for `libz3.so`, you might need to install `libz3-dev`using your usual package manager.*
+
 ### Known Issues
 
 As Z3 is a C library, doing anything weird with it will segfault your process. Ruby API tries its best to prevent such problems and turn them into exceptions instead, but if you do anything weird (especially touch any method prefixed with `_` or `Z3::LowLevel` interface), crashes are possible. If you have reproducible crash on reasonable looking code, definitely submit it as a bug, and I'll try to come up with a workaround.


### PR DESCRIPTION
I tried to use z3 earlier and hit a snag because FFI could not find `libz3.so`. This was solved by installing `libz3-dev`. I'm not sure this is needed on all distributions but I figure the info can be useful to other people so I think it has its place in the README.