### PR TITLE
Ignore RVM local config files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /*.gem
 Gemfile.lock
 /missing_apis.txt
+.ruby-*


### PR DESCRIPTION
This is purely for developer convenience.