### PR TITLE
re-enable Optimize

### DIFF
--- a/lib/z3/optimize.rb
+++ b/lib/z3/optimize.rb
@@ -3,7 +3,6 @@ module Z3
     attr_reader :_optimize
 
     def initialize
-      raise Z3::Exception, "This is known to crash in Z3 4.8.13"
       @_optimize = LowLevel.mk_optimize
       LowLevel.optimize_inc_ref(self)
       reset_model!
@@ -24,9 +23,9 @@ module Z3
       LowLevel.optimize_assert(self, ast)
     end
 
-    def assert_soft(ast)
+    def assert_soft(ast, weight = "1", id = nil)
       reset_model!
-      LowLevel.optimize_assert_soft(self, ast)
+      LowLevel.optimize_assert_soft(self, ast, weight, id)
     end
 
     def check(*args)

--- a/spec/optimize_spec.rb
+++ b/spec/optimize_spec.rb
@@ -2,7 +2,7 @@
 
 # Disabled as it crashes on Z3 4.8.13
 module Z3
-  xdescribe Optimize do
+  describe Optimize do
     let(:optimize) { Optimize.new }
     let(:a) { Z3.Int("a") }
     let(:b) { Z3.Int("b") }
@@ -34,22 +34,21 @@ module Z3
       ])
     end
 
+    it "#assert_soft" do
+      optimize.assert_soft a > 0
+      optimize.assert_soft a < 0
+      optimize.assert_soft a < 10
+      optimize.maximize a
+      expect(optimize).to be_satisfiable
+      expect(optimize.model[a].to_i).to eq 9
+    end
+
     it "#statistics" do
       optimize.assert a + b == 4
       optimize.assert b >= 2
       optimize.assert Z3.Or(a == 2, a == -2)
       stats = optimize.statistics
       expect(stats.keys).to match_array(["rlimit count", "max memory", "memory", "num allocs"])
-    end
-
-    # This is a very simple example of unknown satisfiablity
-    # so we might need more complex one in the future
-    # Unlike Z3::Solver, this is unknown even 4.6.0
-    it "unknown satisfiability" do
-      optimize.assert a**3 == a
-      expect(optimize.check).to eq(:unknown)
-      expect{optimize.satisfiable?}.to raise_error("Satisfiability unknown")
-      expect{optimize.unsatisfiable?}.to raise_error("Satisfiability unknown")
     end
 
     it "unknown satisfiability" do


### PR DESCRIPTION
which works for me (no crashes) on 4.8.14 on macOS 11.5.2

also fix the method signature for assert_soft and add a test.

(and remove a test that fails because z3 is apparently smarter than it was. optimize solves `a**3==a` with `a==0`. `a**a==a` remains unknown)

using these changes I was able to use Z3 to solve an [Advent of Code optimization problem](https://adventofcode.com/2018/day/23) with [this code](https://github.com/jstanley0/advent-2018/blob/main/23b.rb)




