### PR TITLE
Add ArithExpr#abs

### DIFF
--- a/lib/z3/expr/arith_expr.rb
+++ b/lib/z3/expr/arith_expr.rb
@@ -40,6 +40,10 @@ module Z3
       sort.new(LowLevel.mk_unary_minus(self))
     end
 
+    def abs
+      (self < 0).ite(-self, self)
+    end
+
     # Recast so 1 + x:Float
     # is:  (+ 1.0 x)
     # not: (+ (to_real 1) x)

--- a/spec/int_expr_spec.rb
+++ b/spec/int_expr_spec.rb
@@ -81,6 +81,12 @@ module Z3
       expect([a == 3, b == -a]).to have_solution(b => -3)
     end
 
+    it "abs" do
+      expect([a == 3, b == 2, c == (a - b).abs]).to have_solution(c => 1)
+      expect([a == 2, b == 3, c == (a - b).abs]).to have_solution(c => 1)
+      expect([a == 2, b == 2, c == (a - b).abs]).to have_solution(c => 0)
+    end
+
     it "simplify" do
       a = Z3.Const(5)
       b = Z3.Const(3)


### PR DESCRIPTION
Found myself wanting an `abs` method for arithmetic expressions. Thought others might as well.